### PR TITLE
Let service run as acme-dns-pdns user; remove incompatible service op…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,12 @@
     name: acme-dns-pdns
     system: true
 
+- name: Create user
+  user:
+    name: acme-dns-pdns
+    group: acme-dns-pdns
+    state: present
+
 - name: Template script
   template:
     src: server.py.j2
@@ -24,7 +30,7 @@
   copy:
     dest: /etc/acme-dns-pdns.yml
     content: "{{ config }}"
-    owner: root
+    owner: acme-dns-pdns
     group: acme-dns-pdns
     mode: 0640
   notify: Restart acme-dns-pdns
@@ -43,6 +49,7 @@
 - name: Grant access to the pdns config
   file:
     path: /etc/powerdns/pdns.conf
+    owner: acme-dns-pdns
     group: acme-dns-pdns
     mode: g+r
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
     content: "{{ config }}"
     owner: acme-dns-pdns
     group: acme-dns-pdns
-    mode: 0640
+    mode: 0440
   notify: Restart acme-dns-pdns
 
 - name: Template service
@@ -49,7 +49,6 @@
 - name: Grant access to the pdns config
   file:
     path: /etc/powerdns/pdns.conf
-    owner: acme-dns-pdns
     group: acme-dns-pdns
     mode: g+r
 

--- a/templates/acme-dns-pdns.service.j2
+++ b/templates/acme-dns-pdns.service.j2
@@ -17,15 +17,13 @@ ProtectKernelTunables=yes
 ProtectKernelModules=yes
 ProtectControlGroups=yes
 
-User=nobody
+User=acme-dns-pdns
 Group=acme-dns-pdns
 
 CapabilityBoundingSet=
 NoNewPrivileges=yes
 
-LockPersonality=yes
 RestrictRealtime=yes
-PrivateMounts=yes
 PrivateUsers=yes
 SystemCallArchitectures=native
 RestrictAddressFamilies=AF_INET AF_INET6


### PR DESCRIPTION
…tions

Some options were not supported on systemd 232 (= on stretch)